### PR TITLE
Pass options to ros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # auto-ros
 
-[![CI][gh-actions-image]][gh-actions-url] [![NPM version][npm-version-image]][npm-version-url] [![Dependency Status][daviddm-image]][daviddm-url] [![devDependency Status][daviddm-image-dev]][daviddm-url-dev]
+[![CI][gh-actions-image]][gh-actions-url] [![NPM version][npm-version-image]][npm-version-url]
 
 Wrapper of ROSLIB.Ros which automatically reconnects
 
@@ -9,8 +9,3 @@ Wrapper of ROSLIB.Ros which automatically reconnects
 
 [npm-version-image]: https://img.shields.io/npm/v/auto-ros.svg
 [npm-version-url]: https://www.npmjs.com/package/auto-ros
-
-[daviddm-image]: https://david-dm.org/tue-robotics/auto-ros/status.svg
-[daviddm-url]: https://david-dm.org/tue-robotics/auto-ros
-[daviddm-image-dev]: https://david-dm.org/tue-robotics/auto-ros/dev-status.svg
-[daviddm-url-dev]: https://david-dm.org/tue-robotics/auto-ros?type=dev

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ Wrapper of ROSLIB.Ros which automatically reconnects
 
 [npm-version-image]: https://img.shields.io/npm/v/auto-ros.svg
 [npm-version-url]: https://www.npmjs.com/package/auto-ros
+
+## Usage
+
+```js
+import AutoRos from 'auto-ros'
+
+const autoRos = new AutoRos()
+
+autoRos.connect()
+```

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ class AutoRos extends EventEmitter2 {
    * @param {Object} [options]
    * @param {number} [options.reconnectTimeOut=5000] - The reconnect timeout in ms.
    * @param {Object} [options.rosOptions] - Option object passed to the constructor of the ROSLIB.Ros object.
+   * @param {string} [options.rosOptions.encoding=ascii] - See ROSLIB docs
+   * @param {string} [options.rosOptions.transportLibrary=websocket] - See ROSLIB docs
    */
   constructor (options) {
     super()

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,20 @@ const defaultUrl = `ws://${host}:9090`
 const RECONNECT_TIMEOUT = 5000
 
 class AutoRos extends EventEmitter2 {
-  constructor () {
+  constructor (options) {
     super()
 
-    this.ros = new ROSLIB.Ros({
-      encoding: 'ascii'
-    })
+    options = options || {}
+    if (!options.hasOwnProperty('encoding')) {
+        options.encoding = 'ascii'
+    }
+    if (!options.hasOwnProperty('transportLibrary')) {
+        options.transportLibrary = 'websocket'
+    }
+
+    console.log('Creating ROS with the options:', options)
+
+    this.ros = new ROSLIB.Ros(options)
 
     this._status = 'closed'
 
@@ -66,4 +74,4 @@ class AutoRos extends EventEmitter2 {
   }
 }
 
-export default new AutoRos()
+export default AutoRos

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ class AutoRos extends EventEmitter2 {
   /**
    * Auto reconnecting wrapper of ROSLIB.Ros
    *
-   * @param {Object} options
-   * @param {number} options.reconnectTimeOut - The reconnect timeout in ms.
-   * @param {Object} options.rosOptions - Option object passed to the constructor of the ROSLIB.Ros object.
+   * @param {Object} [options]
+   * @param {number} [options.reconnectTimeOut=5000] - The reconnect timeout in ms.
+   * @param {Object} [options.rosOptions] - Option object passed to the constructor of the ROSLIB.Ros object.
    */
   constructor (options) {
     super()

--- a/src/index.js
+++ b/src/index.js
@@ -14,16 +14,15 @@ class AutoRos extends EventEmitter2 {
     super()
 
     options = options || {}
-    if (!options.hasOwnProperty('encoding')) {
-        options.encoding = 'ascii'
-    }
-    if (!options.hasOwnProperty('transportLibrary')) {
-        options.transportLibrary = 'websocket'
-    }
+    this._reconnectTimeOut = options.reconnectTimeOut || RECONNECT_TIMEOUT
 
-    console.log('Creating ROS with the options:', options)
+    var rosOptions = options.rosOptions || {}
+    rosOptions.encoding = rosOptions.encoding || 'ascii'
+    rosOptions.transportLibrary = rosOptions.transportLibrary || 'websocket'
 
-    this.ros = new ROSLIB.Ros(options)
+    console.debug('Creating ROS with the options:', rosOptions)
+
+    this.ros = new ROSLIB.Ros(rosOptions)
 
     this._status = 'closed'
 
@@ -63,7 +62,7 @@ class AutoRos extends EventEmitter2 {
   }
 
   onClose () {
-    setTimeout(this.connect.bind(this), RECONNECT_TIMEOUT)
+    setTimeout(this.connect.bind(this), this._reconnectTimeOut)
     console.log('connection closed')
     this.status = 'closed'
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,13 @@ const defaultUrl = `ws://${host}:9090`
 const RECONNECT_TIMEOUT = 5000
 
 class AutoRos extends EventEmitter2 {
+  /**
+   * Auto reconnecting wrapper of ROSLIB.Ros
+   *
+   * @param {Object} options
+   * @param {number} options.reconnectTimeOut - The reconnect timeout in ms.
+   * @param {Object} options.rosOptions - Option object passed to the constructor of the ROSLIB.Ros object.
+   */
   constructor (options) {
     super()
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,7 @@ class AutoRos extends EventEmitter2 {
    * @param {Object} [options]
    * @param {number} [options.reconnectTimeOut=5000] - The reconnect timeout in ms.
    * @param {Object} [options.rosOptions] - Option object passed to the constructor of the ROSLIB.Ros object.
-   * @param {string} [options.rosOptions.encoding=ascii] - See ROSLIB docs
-   * @param {string} [options.rosOptions.transportLibrary=websocket] - See ROSLIB docs
+   * @param {string} [options.rosOptions.encoding=ascii] - Overruling the default of ROSLIB, which is 'utf8'.
    */
   constructor (options) {
     super()
@@ -27,7 +26,11 @@ class AutoRos extends EventEmitter2 {
 
     var rosOptions = options.rosOptions || {}
     rosOptions.encoding = rosOptions.encoding || 'ascii'
-    rosOptions.transportLibrary = rosOptions.transportLibrary || 'websocket'
+
+    if ('url' in rosOptions)
+    {
+      throw '"url" option to ROS is not allowed. Connect by calling the connect function on this object with the "url" as argument'
+    }
 
     console.debug('Creating ROS with the options:', rosOptions)
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,9 +8,9 @@ import AutoRos from '..'
 chai.use(sinonChai)
 const should = chai.should()
 
-describe('AutoRos', () => {
-  const exampleUrl = 'ws://example.com:9090'
+const exampleUrl = 'ws://example.com:9090'
 
+describe('AutoRos', () => {
   let options = {}
   let autoRos
   beforeEach('create a AutoRos', () => {
@@ -174,3 +174,14 @@ describe('AutoRos', () => {
     })
   })
 })
+
+describe('rosOptions.url is not allowed', () => {
+
+    it('Constructor should throw', () => {
+      const options = {rosOptions: {url: exampleUrl}}
+      var badConstructor = function() {
+      return new AutoRos(options)
+      }
+      badConstructor.should.throw(/url/)
+    })
+  })

--- a/test/test.js
+++ b/test/test.js
@@ -11,14 +11,14 @@ const should = chai.should()
 describe('AutoRos', () => {
   const exampleUrl = 'ws://example.com:9090'
 
-  let auto_ros
+  let autoRos
   beforeEach('create a AutoRos', () => {
-    auto_ros = new AutoRos.constructor()
+    autoRos = new AutoRos()
   })
 
   let connect
   beforeEach('Stub connect', () => {
-    connect = stub(auto_ros.ros, 'connect')
+    connect = stub(autoRos.ros, 'connect')
     connect.returns()
   })
 
@@ -29,14 +29,14 @@ describe('AutoRos', () => {
   describe('AutoRos.connect', () => {
     it('Should connect to a custom url', () => {
       connect.should.have.not.been.called
-      auto_ros.connect(exampleUrl)
+      autoRos.connect(exampleUrl)
       connect.should.have.been.calledOnce
       connect.should.have.been.calledWithExactly(exampleUrl)
     })
 
     it('Should connect to a default url', () => {
       connect.should.have.not.been.called
-      auto_ros.connect()
+      autoRos.connect()
       connect.should.have.been.calledOnce
       connect.should.have.been.calledWithMatch(/ws:\/\/[a-zA-Z\d-.]+:9090/)
     })
@@ -44,10 +44,10 @@ describe('AutoRos', () => {
     it('Should remember the previous url', () => {
       connect.should.have.not.been.called
 
-      auto_ros.connect(exampleUrl)
+      autoRos.connect(exampleUrl)
       connect.should.have.been.calledOnce
 
-      auto_ros.connect()
+      autoRos.connect()
       connect.should.have.been.calledTwice
       connect.should.always.have.been.calledWithExactly(exampleUrl)
     })
@@ -61,17 +61,17 @@ describe('AutoRos', () => {
     beforeEach('Stub ros.socket.send', () => {
       // stub callOnConnection to prevent sending something on the websocket
       should.not.exist(null)
-      should.not.exist(auto_ros.ros.socket)
+      should.not.exist(autoRos.ros.socket)
 
       send = stub()
       send.returns()
-      auto_ros.ros.socket = {
+      autoRos.ros.socket = {
         send
       }
     })
 
     afterEach('Stub callOnConnection', () => {
-      auto_ros.ros.socket = null
+      autoRos.ros.socket = null
     })
 
     let clock
@@ -87,26 +87,26 @@ describe('AutoRos', () => {
      * Tests
      */
     it('Should have a default status', () => {
-      auto_ros.status.should.equal('closed')
+      autoRos.status.should.equal('closed')
     })
 
     it('Should respond to the ros::connection event', () => {
-      auto_ros.connect(exampleUrl)
-      auto_ros.status.should.equal('connecting')
+      autoRos.connect(exampleUrl)
+      autoRos.status.should.equal('connecting')
       connect.should.have.been.calledOnce
       connect.should.have.been.calledWithExactly(exampleUrl)
 
-      auto_ros.ros.emit('connection')
-      auto_ros.status.should.equal('connected')
+      autoRos.ros.emit('connection')
+      autoRos.status.should.equal('connected')
     })
 
     it('Should reconnect after the ros::closed event', () => {
-      auto_ros.connect(exampleUrl)
+      autoRos.connect(exampleUrl)
       connect.should.have.been.calledOnce
       connect.should.have.been.calledWithExactly(exampleUrl)
 
-      auto_ros.ros.emit('close')
-      auto_ros.status.should.equal('closed')
+      autoRos.ros.emit('close')
+      autoRos.status.should.equal('closed')
       clock.tick(500)
 
       connect.should.have.been.calledOnce
@@ -119,8 +119,8 @@ describe('AutoRos', () => {
     })
 
     it('Should respond to the ros::error event', () => {
-      auto_ros.ros.emit('error')
-      auto_ros.status.should.equal('error')
+      autoRos.ros.emit('error')
+      autoRos.status.should.equal('error')
     })
   })
 })


### PR DESCRIPTION
This PR allows for passing options to the internal ROS object. It also enables a custom reconnect timeout.

This is a breaking change. So this will result in a major version bump.