### PR TITLE
(actions) generate docs on tags, not releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Docs Deployment
 
 on:
-  release:
-    types: [released]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   docs:


### PR DESCRIPTION
As the release is created by another action. For security reasons, such event will not trigger another action.